### PR TITLE
Catch C++ exceptions from node_map functions

### DIFF
--- a/examples/async-grab.rs
+++ b/examples/async-grab.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
     // sets up free-running continuous acquisition.
     camera.start_grabbing(&pylon_cxx::GrabOptions::default().count(COUNT_IMAGES_TO_GRAB))?;
 
-    match camera.node_map().enum_node("PixelFormat") {
+    match camera.node_map()?.enum_node("PixelFormat") {
         Ok(node) => println!(
             "pixel format: {}",
             node.value().unwrap_or("could not read value".to_string())

--- a/examples/feature-persistence.rs
+++ b/examples/feature-persistence.rs
@@ -13,10 +13,10 @@ fn main() -> anyhow::Result<()> {
     let filename = "NodeMap.pfs";
 
     println!("Saving camera's node map to file \"{}\".", filename);
-    camera.node_map().save(filename)?;
+    camera.node_map()?.save(filename)?;
 
     println!("Reading file back to camera's node map.");
-    camera.node_map().load(filename, true)?;
+    camera.node_map()?.load(filename, true)?;
 
     println!("Ok.");
     Ok(())

--- a/examples/grab.rs
+++ b/examples/grab.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
     // sets up free-running continuous acquisition.
     camera.start_grabbing(&pylon_cxx::GrabOptions::default().count(COUNT_IMAGES_TO_GRAB))?;
 
-    match camera.node_map().enum_node("PixelFormat") {
+    match camera.node_map()?.enum_node("PixelFormat") {
         Ok(node) => println!(
             "pixel format: {}",
             node.value().unwrap_or("could not read value".to_string())

--- a/examples/reset-all-devices.rs
+++ b/examples/reset-all-devices.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
         camera.open()?;
 
         {
-            let node = camera.node_map().command_node("DeviceReset")?;
+            let node = camera.node_map()?.command_node("DeviceReset")?;
             print!("  resetting...");
             node.execute(true)?;
             println!("OK");

--- a/examples/show-pixel-formats.rs
+++ b/examples/show-pixel-formats.rs
@@ -7,7 +7,7 @@ fn main() -> anyhow::Result<()> {
 
     camera.open()?;
 
-    let pixel_format_node = camera.node_map().enum_node("PixelFormat")?;
+    let pixel_format_node = camera.node_map()?.enum_node("PixelFormat")?;
     for v in pixel_format_node.settable_values()? {
         println!("{}", v);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,17 +123,18 @@ mod ffi {
             timeout_handling: TimeoutHandling,
         ) -> Result<bool>;
 
-        fn instant_camera_get_node_map(camera: &UniquePtr<CInstantCamera>) -> &MyNodeMap;
-        fn instant_camera_get_tl_node_map(camera: &UniquePtr<CInstantCamera>) -> &MyNodeMap;
+        fn instant_camera_get_node_map(camera: &UniquePtr<CInstantCamera>) -> Result<&MyNodeMap>;
+        fn instant_camera_get_tl_node_map(camera: &UniquePtr<CInstantCamera>)
+            -> Result<&MyNodeMap>;
         fn instant_camera_get_stream_grabber_node_map(
             camera: &UniquePtr<CInstantCamera>,
-        ) -> &MyNodeMap;
+        ) -> Result<&MyNodeMap>;
         fn instant_camera_get_event_grabber_node_map(
             camera: &UniquePtr<CInstantCamera>,
-        ) -> &MyNodeMap;
+        ) -> Result<&MyNodeMap>;
         fn instant_camera_get_instant_camera_node_map(
             camera: &UniquePtr<CInstantCamera>,
-        ) -> &MyNodeMap;
+        ) -> Result<&MyNodeMap>;
 
         fn node_map_load(node_map: &MyNodeMap, filename: String, validate: bool) -> Result<()>;
         fn node_map_save(node_map: &MyNodeMap, filename: String) -> Result<()>;
@@ -596,35 +597,35 @@ impl<'a> InstantCamera<'a> {
 
 /// These methods return the various node maps.
 impl<'a> InstantCamera<'a> {
-    pub fn node_map<'map>(&'a self) -> NodeMap<'map, 'a> {
-        NodeMap {
-            inner: ffi::instant_camera_get_node_map(&self.inner),
+    pub fn node_map<'map>(&'a self) -> PylonResult<NodeMap<'map, 'a>> {
+        Ok(NodeMap {
+            inner: ffi::instant_camera_get_node_map(&self.inner)?,
             parent: std::marker::PhantomData,
-        }
+        })
     }
-    pub fn tl_node_map<'map>(&'a self) -> NodeMap<'map, 'a> {
-        NodeMap {
-            inner: ffi::instant_camera_get_tl_node_map(&self.inner),
+    pub fn tl_node_map<'map>(&'a self) -> PylonResult<NodeMap<'map, 'a>> {
+        Ok(NodeMap {
+            inner: ffi::instant_camera_get_tl_node_map(&self.inner)?,
             parent: std::marker::PhantomData,
-        }
+        })
     }
-    pub fn stream_grabber_node_map<'map>(&'a self) -> NodeMap<'map, 'a> {
-        NodeMap {
-            inner: ffi::instant_camera_get_stream_grabber_node_map(&self.inner),
+    pub fn stream_grabber_node_map<'map>(&'a self) -> PylonResult<NodeMap<'map, 'a>> {
+        Ok(NodeMap {
+            inner: ffi::instant_camera_get_stream_grabber_node_map(&self.inner)?,
             parent: std::marker::PhantomData,
-        }
+        })
     }
-    pub fn event_grabber_node_map<'map>(&'a self) -> NodeMap<'map, 'a> {
-        NodeMap {
-            inner: ffi::instant_camera_get_event_grabber_node_map(&self.inner),
+    pub fn event_grabber_node_map<'map>(&'a self) -> PylonResult<NodeMap<'map, 'a>> {
+        Ok(NodeMap {
+            inner: ffi::instant_camera_get_event_grabber_node_map(&self.inner)?,
             parent: std::marker::PhantomData,
-        }
+        })
     }
-    pub fn instant_camera_node_map<'map>(&'a self) -> NodeMap<'map, 'a> {
-        NodeMap {
-            inner: ffi::instant_camera_get_instant_camera_node_map(&self.inner),
+    pub fn instant_camera_node_map<'map>(&'a self) -> PylonResult<NodeMap<'map, 'a>> {
+        Ok(NodeMap {
+            inner: ffi::instant_camera_get_instant_camera_node_map(&self.inner)?,
             parent: std::marker::PhantomData,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
By returning a `PylonResult` from the `node_map` function all thrown C++ exceptions are automatically caught and converted to PylonResult by cxx.

fixes #10