### PR TITLE
Fix problem with repeated start and stop grabbing in async code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,10 @@ impl<'a> InstantCamera<'a> {
     }
 
     pub fn stop_grabbing(&self) -> PylonResult<()> {
-        ffi::instant_camera_stop_grabbing(&self.inner).into_rust()
+        ffi::instant_camera_stop_grabbing(&self.inner).into_rust()?;
+        #[cfg(feature = "stream")]
+        self.fd.replace(None);
+        Ok(())
     }
 
     pub fn is_grabbing(&self) -> bool {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -90,4 +90,23 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn start_stop_loop_works() -> PylonResult<()> {
+        let pylon = Pylon::new();
+        let cam = TlFactory::instance(&pylon).create_first_device()?;
+        cam.open()?;
+        tokio::pin!(cam);
+        for _ in 0..5 {
+            let mut images = 10;
+            cam.start_grabbing(&GrabOptions::default().count(images))?;
+            while let Some(res) = cam.next().await {
+                images -= 1;
+                assert!(res.grab_succeeded()?);
+            }
+            assert_eq!(images, 0);
+            cam.stop_grabbing()?;
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
The filedescriptor was not reset on stop grabbing, which caused a C++ exception on restarting the grabbing.

This start and stop grabbing is necessary with linescan cameras to have a deterministic image start and end.

Also added testcase which fails with the old version.